### PR TITLE
Fixed erroneous gas computation for fixed operation 

### DIFF
--- a/neo-gui/UI/InvokeContractDialog.cs
+++ b/neo-gui/UI/InvokeContractDialog.cs
@@ -144,8 +144,7 @@ namespace Neo.UI
             engine.LoadScript(tx.Script, false);
             if (engine.Execute())
             {
-                tx.Gas = engine.GasConsumed - Fixed8.FromDecimal(10);
-                if (tx.Gas < Fixed8.One) tx.Gas = Fixed8.One;
+                tx.Gas = (engine.GasConsumed < Fixed8.FromDecimal(10)) ? Fixed8.One : engine.GasConsumed;
                 tx.Gas = tx.Gas.Ceiling();
                 label7.Text = tx.Gas + " gas";
                 button3.Enabled = true;


### PR DESCRIPTION
This is for transaction like contract deployment (500 GAS) or asset creation (5000 GAS). It seems to me this is the right meaning when reading this on the white paper:

> For most simple contracts, they can be executed **for free, so long as the execution costs remain under 10 GAS**, thus greatly reducing costs for the user.

Removing 10 GAS to all transactions it seems to me to have no sense at all.

Side note: I can't understand why the previous commit changed the minimum gas from 0 to 1, but if it is correct I suggest to change the white paper to something like this:

> For most simple contracts, they can be executed for **1 GAS as long as the execution costs remain under 10 GAS**, thus greatly reducing costs for the user.