### PR TITLE
Fix #19: UI crash when chain is not synchronized before NeoCoin claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+Project Setup
+=============
+
+To build and run locally, you need to clone and build https://github.com/neo-project/leveldb first, 
+then copy `libleveldb.dll` to the working directory (i.e. /bin/Debug, /bin/Release)
+
+Note: When building, the project file settings must be changed from static library (lib) to dynamic linked library (dll).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 Project Setup
 =============
 
+On Linux:
+=========
+`yum install leveldb-devel`
+
+On Windows:
+===========
+
 To build and run locally, you need to clone and build https://github.com/neo-project/leveldb first, 
 then copy `libleveldb.dll` to the working directory (i.e. /bin/Debug, /bin/Release)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,0 @@
-Project Setup
-=============
-
-To build and run locally, you need to clone and build https://github.com/neo-project/leveldb first, 
-then copy `libleveldb.dll` to the working directory (i.e. /bin/Debug, /bin/Release)
-
-Note: When building, the project file settings must be changed from static library (lib) to dynamic linked library (dll).

--- a/neo-gui.sln
+++ b/neo-gui.sln
@@ -1,14 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.3
+VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "neo-gui", "neo-gui\neo-gui.csproj", "{CFC243F0-F4E3-4754-8E21-8BA17E1C1788}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{17B01124-9D2B-4629-978C-901C781D0B27}"
-	ProjectSection(SolutionItems) = preProject
-		README.md = README.md
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,8 +18,5 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {199E20B3-E3CC-44E7-8C22-C5C86146A9CF}
 	EndGlobalSection
 EndGlobal

--- a/neo-gui.sln
+++ b/neo-gui.sln
@@ -1,9 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.15
+VisualStudioVersion = 15.0.26730.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "neo-gui", "neo-gui\neo-gui.csproj", "{CFC243F0-F4E3-4754-8E21-8BA17E1C1788}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{17B01124-9D2B-4629-978C-901C781D0B27}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +23,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {199E20B3-E3CC-44E7-8C22-C5C86146A9CF}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Filter out any coin references we can't find in local chain, since CalculateBonus is more strict and assumes a complete height.