### PR TITLE
added wallet height to infobar for rebuild progress indication

### DIFF
--- a/neo-gui/UI/MainForm.cs
+++ b/neo-gui/UI/MainForm.cs
@@ -292,7 +292,15 @@ namespace Neo.UI
 
         private void timer1_Tick(object sender, EventArgs e)
         {
-            lbl_height.Text = $"{Blockchain.Default.Height}/{Blockchain.Default.HeaderHeight}";
+            uint walletHeight = 0;
+
+            if (Program.CurrentWallet != null)
+            {
+                walletHeight = (Program.CurrentWallet.WalletHeight > 0) ? Program.CurrentWallet.WalletHeight - 1 : 0;
+            }
+
+            lbl_height.Text = $"{walletHeight}/{Blockchain.Default.Height}/{Blockchain.Default.HeaderHeight}";
+
             lbl_count_node.Text = Program.LocalNode.RemoteNodeCount.ToString();
             TimeSpan persistence_span = DateTime.UtcNow - persistence_time;
             if (persistence_span < TimeSpan.Zero) persistence_span = TimeSpan.Zero;

--- a/neo-gui/UI/MainForm.resx
+++ b/neo-gui/UI/MainForm.resx
@@ -584,7 +584,7 @@
     <value>27, 17</value>
   </data>
   <data name="lbl_height.Text" xml:space="preserve">
-    <value>0/0</value>
+    <value>0/0/0</value>
   </data>
   <data name="toolStripStatusLabel4.Size" type="System.Drawing.Size, System.Drawing">
     <value>73, 17</value>


### PR DESCRIPTION
A longstanding complaint with the GUI in the support channel in Slack is the inability to see a progress indication during a wallet index rebuild.

This simple fix adds the wallet height to the information bar, prepended to the local db and blockchain height count, as a way of giving visual feedback on the progress of the wallet rebuild, without having to construct a modal dialog or disappearing progress bar.
