### PR TITLE
修复启动时无法加载插件的错误，错误信息如下

### DIFF
--- a/neo-gui/App.config
+++ b/neo-gui/App.config
@@ -5,6 +5,9 @@
       <section name="Neo.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
     </sectionGroup>
   </configSections>
+  <runtime>
+    <loadFromRemoteSources enabled="true"/>
+  </runtime>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
   </startup>


### PR DESCRIPTION
System.NotSupportedException
尝试从一个网络位置加载程序集，在早期版本的 .NET Framework 中，这会导致对该程序集进行沙盒处理。此发行版的 .NET Framework 默认情况下不启用 CAS 策略，因此，此加载可能会很危险。如果此加载不是要对程序集进行沙盒处理，请启用 loadFromRemoteSources 开关。有关详细信息，请参见 http://go.microsoft.com/fwlink/?LinkId=155569。
   在 System.Reflection.RuntimeAssembly.nLoadFile(String path, Evidence evidence)
   在 System.Reflection.Assembly.LoadFile(String path)
   在 Neo.Plugins.Plugin.LoadPlugins(NeoSystem system)
   在 Neo.Program.Main()